### PR TITLE
Fix data stacking to include non form element type elements such as <mat-checkbox>

### DIFF
--- a/xp-form.html
+++ b/xp-form.html
@@ -135,8 +135,13 @@ This element is used to add XHR capabilities to the standard HTML form.
                 var self = this,
                     json = {};
 
+		// this is done so that mat-checkbox etc. work
+		// properly.  form.elements does not pull those
+		// controls out.
+
+		var elements = self.querySelectorAll('[name]');
                 // Stacking
-                XP.forEach(self.elements, function (element) {
+                XP.forEach(elements, function (element) {
 
                     // Vars
                     var value = XP.getValue(element, self.casted),


### PR DESCRIPTION
changed the element stacker to pull all elements that have
the name attribute, rather than using form.elements because
form.elements ignores <mat-checkbox> etc. there may be a better
way to do this with live nodes using `.childNodes` however I
did not think that was necessary considering form.elements is not
live either.
